### PR TITLE
fix: display name

### DIFF
--- a/action.js
+++ b/action.js
@@ -16,7 +16,7 @@ module.exports = class {
   async execute () {
     const myself = await this.Jira.getMyself()
 
-    console.log(`Logged in as: ${myself.name}`)
+    console.log(`Logged in as: ${myself.displayName}`)
 
     return this.config
   }


### PR DESCRIPTION
Hi, 

Atlassian API returns something like this: 

```json
{
    "self": "",
    "accountId": "",
    "emailAddress": "",
    "avatarUrls": {
        "48x48": "",
        "24x24": "",
        "16x16": "",
        "32x32": ""
    },
    "displayName": "",
    "active": true,
    "timeZone": "",
    "locale": "",
    "groups": {
        "size": 0,
        "items": []
    },
    "applicationRoles": {
        "size": 0,
        "items": []
    },
    "expand": "groups,applicationRoles"
}
```

That's why, we keep seeing a weird message in GitHub Actions logs like:

> Logged in as: undefined

This change is to fix that problem, and to display correct name value.

Best,
G.