### PR TITLE
Update node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,5 +4,5 @@ branding:
   icon: 'log-in'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: './dist/index.js'


### PR DESCRIPTION
As per [Github's own blog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), we need to upgrade to Node 16 before Summer 2023 when they remove all Node 12 actions.